### PR TITLE
add $NOTES_USER to docker_compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - POSTGRES_USER=$POSTGRES_USER
       - POSTGRES_PASSWORD=$POSTGRES_PASSWORD
       - POSTGRES_DB=$POSTGRES_DB
+      - NOTES_USER=$NOTES_USER
 
     restart: unless-stopped
 


### PR DESCRIPTION
$NOTES_USER was missing in docker_compose and therefore the env used while creating the container was never handed over